### PR TITLE
build: Helper rules for terms and conditions pdf

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,8 @@ dist_js_DATA = \
 	licenseCrawler.js \
 	$(NULL)
 
-dist_pkgdata_DATA = EndlessOS-terms-conditions.pdf
+EOS_TERMS_PDF = EndlessOS-terms-conditions.pdf
+dist_pkgdata_DATA = $(EOS_TERMS_PDF)
 
 eos-license-service.service: eos-license-service.service.in Makefile
 	@sed -e "s|\@pkgdatadir\@|$(pkgdatadir)|" $< > $@
@@ -21,3 +22,25 @@ MAINTAINERCLEANFILES = \
 	$(NULL)
 
 -include $(top_srcdir)/git.mk
+
+# Helper rules for regenerating the terms and conditions pdf
+EOS_TERMS_URL = https://docs.google.com/a/endlessm.com/document/d/1Nj5yYpTT9BXTNXCKxZXeMgsJ73u9JyFJYQ5gEAFmNOc
+download-terms:
+	xdg-open "$(EOS_TERMS_URL)" &
+	@echo "Export PDF through the 'File->Download as->PDF document (.pdf)' menu"
+	@echo "Save the PDF as $(abs_srcdir)/$(EOS_TERMS_PDF)"
+
+FIX_PDF_LINKS = sed -e \
+	'/^\/URI /{ \
+	  s,(https\?://www.google.com/url?q=,(,; \
+	  s,%3A,:,g; \
+	  s,%2F,/,g; \
+	  s,&sa.*),),; \
+	}'
+fix-terms-links: $(EOS_TERMS_PDF)
+	cp $< $<.orig
+	$(FIX_PDF_LINKS) $<.orig > $<
+	diff -ua $<.orig $<
+	rm $<.orig
+
+.PHONY: download-terms fix-terms-links


### PR DESCRIPTION
Add a couple make rules for downloading the pdf from google docs and
then fixing the links in it. Run "make download-terms" to open the
google doc in your browser. After saving to the appropriate location,
run "make fix-terms-links" to strip the google.com wrapping in the URLs.

[endlessm/eos-shell#3970]
