### PR TITLE
Show one package (group) per page

### DIFF
--- a/licenseApp.js
+++ b/licenseApp.js
@@ -10,7 +10,8 @@ function serverListen(server) {
     if (GLib.getenv('LISTEN_FDS') !== null) {
         server.listen_fd(3, 0);
     } else {
-        server.listen_local(DEFAULT_PORT, 0);
+        const port = Number.parseInt(GLib.getenv('LISTEN_PORT'), 10);
+        server.listen_local(isNaN(port) ? DEFAULT_PORT : port, 0);
     }
 }
 

--- a/licenseApp.js
+++ b/licenseApp.js
@@ -20,5 +20,10 @@ let server = new Soup.Server();
 server.add_handler('/', function(server, msg, path, query, client) {
     licenseCrawler.getLicenseList(msg);
 });
+// /package/foo,bar,baz => license for package foo, shared with bar and baz
+server.add_handler('/package', function(server, msg, path, query, client) {
+    const packageNames = path.slice('/package/'.length).split(',');
+    licenseCrawler.getLicense(msg, packageNames);
+})
 serverListen(server);
 mainloop.run();

--- a/licenseCrawler.js
+++ b/licenseCrawler.js
@@ -47,30 +47,31 @@ function listPackages() {
     return packages;
 }
 
-function getLicenseList(msg) {
-    const htmlMeta =
-        '<meta charset="UTF-8">';
-    const htmlStyle =
-        '<style>\n' +
-        'body{margin:50px;min-width:630px;font-family: sans-serif;}\n' +
-        'h2{border-top:5px solid #4a4a4a;padding-top:20px;font-size:28px;line-height:34px;margin-top:70px;}\n' +
-        'h3{border-top:solid 1px #d8d8d8;padding-top:20px;font-size:22px;line-height:26px;clear:both;margin-top:50px;}\n' +
-        'p{font-size:18px;line-height:28px;}\n' +
-        '.copyright { font-family: monospace; font-size: initial; font-weight: initial; -moz-tab-size: 4; tab-size: 4; white-space: pre-wrap; }\n' +
-        '</style>\n';
-    const htmlHeader =
-        '<html>\n' +
-        '<head>\n' +
-        htmlMeta +
-        htmlStyle +
-        '</head>\n' +
-        '<body>\n' +
-        '<h2>Open Source Software</h2>\n';
-        // Happy preamble of legal compliance goes here...
-    const htmlFooter =
-        '</body>\n' +
-        '</html>';
+const htmlMeta =
+    '<meta charset="UTF-8">';
+const htmlStyle =
+    '<style>\n' +
+    'body{margin:50px;min-width:630px;font-family: sans-serif;}\n' +
+    'h2{border-top:5px solid #4a4a4a;padding-top:20px;font-size:28px;line-height:34px;margin-top:70px;}\n' +
+    'h3{border-top:solid 1px #d8d8d8;padding-top:20px;font-size:22px;line-height:26px;clear:both;margin-top:50px;}\n' +
+    'p{font-size:18px;line-height:28px;}\n' +
+    'a{color: inherit;}\n' +
+    '.copyright { font-family: monospace; font-size: initial; font-weight: initial; -moz-tab-size: 4; tab-size: 4; white-space: pre-wrap; }\n' +
+    '</style>\n';
+const htmlHeader =
+    '<html>\n' +
+    '<head>\n' +
+    htmlMeta +
+    htmlStyle +
+    '</head>\n' +
+    '<body>\n' +
+    '<h2><a href="/">Open Source Software</a></h2>\n';
+    // Happy preamble of legal compliance goes here...
+const htmlFooter =
+    '</body>\n' +
+    '</html>';
 
+function getLicenseList(msg) {
     // send the HTML header
     msg.status_code = 200;
     msg.response_headers.set_encoding(Soup.Encoding.CHUNKED);
@@ -83,28 +84,54 @@ function getLicenseList(msg) {
     packageNames.sort();
     packageNames.forEach(function(packageName) {
         const copyrightPath = GLib.build_filenamev([CRAWL_LOCATION, packageName, 'copyright']);
-
-        try {
-            const [success, copyrightContents] = GLib.file_get_contents(copyrightPath);
-        } catch (e if e.matches(GLib.FileError, GLib.FileError.NOENT)) {
-            return;
-        } catch (e) {
-            logError(e, 'Unable to read copyright file ' + copyrightPath);
+        const copyrightFile = Gio.File.new_for_path(copyrightPath);
+        if (!copyrightFile.query_exists(null)) {
             return;
         }
 
         const dirNames = packages[packageName];
-
-        // send HTML for this directory
-        try {
-            const html = prepareHtml(dirNames, copyrightContents.toString());
-            msg.response_body.append(html);
-        } catch (e) {
-            logError(e, 'Unable to convert contents of ' + copyrightPath + ' to string');
-        }
+        msg.response_body.append('<li class="package-name">');
+        msg.response_body.append('<a href="/package/' + dirNames.join(',') + '">');
+        msg.response_body.append(dirNames.join(', '));
+        msg.response_body.append('</a></li>\n');
     });
 
     // send the HTML footer and end request
     msg.response_body.append(htmlFooter);
     msg.response_body.complete();
 };
+
+function getLicense(msg, packageNames) {
+    const packageName = packageNames[0];
+    const copyrightPath = GLib.build_filenamev([CRAWL_LOCATION, packageName, 'copyright']);
+    var statusCode = 200;
+    var html = '';
+
+    try {
+        const [success, copyrightContents] = GLib.file_get_contents(copyrightPath);
+
+        try {
+            html = prepareHtml(packageNames, copyrightContents.toString());
+        } catch (e) {
+            html = 'Unable to convert contents of ' + copyrightPath + ' to string';
+            logError(e, html);
+            statusCode = 500;
+        }
+    } catch (e if e.matches(GLib.FileError, GLib.FileError.NOENT)) {
+        statusCode = 400;
+        html = 'Not found: ' + copyrightPath;
+    } catch (e) {
+        html = 'Unable to read copyright file: ' + copyrightPath;
+        logError(e, html);
+        statusCode = 500;
+    }
+
+    // send the HTML header
+    msg.status_code = statusCode;
+    msg.response_headers.set_encoding(Soup.Encoding.CHUNKED);
+    msg.response_headers.set_content_type('text/html', { charset: 'UTF-8' });
+    msg.response_body.append(htmlHeader);
+    msg.response_body.append(html);
+    msg.response_body.append(htmlFooter);
+    msg.response_body.complete();
+}

--- a/licenseCrawler.js
+++ b/licenseCrawler.js
@@ -6,15 +6,7 @@ const Soup = imports.gi.Soup;
 const CRAWL_LOCATION = '/usr/share/doc';
 
 function prepareHtml(fileNames, copyright) {
-    // http://stackoverflow.com/questions/5007574
-    var sanitizedCopyright = copyright
-	.replace(/&/g, '&amp;')
-	.replace(/</g, '&lt;')
-	.replace(/>/g, '&gt;')
-	.replace(/\t/g, '    ')
-	.replace(/  /g, '&nbsp; ')
-	.replace(/  /g, ' &nbsp;')
-	.replace(/\r\n|\n|\r/g, '<br />');
+    var sanitizedCopyright = GLib.markup_escape_text(copyright, -1);
 
     var html = '<h3 class="package-name">';
     var files = [];
@@ -68,7 +60,7 @@ function getLicenseList(msg) {
 	'h2{border-top:5px solid #4a4a4a;padding-top:20px;font-size:28px;line-height:34px;margin-top:70px;}\n' +
 	'h3{border-top:solid 1px #d8d8d8;padding-top:20px;font-size:22px;line-height:26px;clear:both;margin-top:50px;}\n' +
 	'p{font-size:18px;line-height:28px;}\n' +
-	'.copyright { font-family: monospace; font-size: initial; font-weight: initial; }\n' +
+	'.copyright { font-family: monospace; font-size: initial; font-weight: initial; -moz-tab-size: 4; tab-size: 4; white-space: pre-wrap; }\n' +
 	'</style>\n';
     const htmlHeader =
 	'<html>\n' +

--- a/licenseCrawler.js
+++ b/licenseCrawler.js
@@ -29,7 +29,7 @@ function prepareHtml(fileNames, copyright) {
     html += '<p class="copyright">';
     html += sanitizedCopyright;
     html += '</p>';
-    html += '\n'
+    html += '\n';
 
     return html;
 }

--- a/licenseCrawler.js
+++ b/licenseCrawler.js
@@ -49,27 +49,27 @@ function listPackages() {
 
 function getLicenseList(msg) {
     const htmlMeta =
-	'<meta charset="UTF-8">';
+        '<meta charset="UTF-8">';
     const htmlStyle =
-	'<style>\n' +
-	'body{margin:50px;min-width:630px;font-family: sans-serif;}\n' +
-	'h2{border-top:5px solid #4a4a4a;padding-top:20px;font-size:28px;line-height:34px;margin-top:70px;}\n' +
-	'h3{border-top:solid 1px #d8d8d8;padding-top:20px;font-size:22px;line-height:26px;clear:both;margin-top:50px;}\n' +
-	'p{font-size:18px;line-height:28px;}\n' +
-	'.copyright { font-family: monospace; font-size: initial; font-weight: initial; -moz-tab-size: 4; tab-size: 4; white-space: pre-wrap; }\n' +
-	'</style>\n';
+        '<style>\n' +
+        'body{margin:50px;min-width:630px;font-family: sans-serif;}\n' +
+        'h2{border-top:5px solid #4a4a4a;padding-top:20px;font-size:28px;line-height:34px;margin-top:70px;}\n' +
+        'h3{border-top:solid 1px #d8d8d8;padding-top:20px;font-size:22px;line-height:26px;clear:both;margin-top:50px;}\n' +
+        'p{font-size:18px;line-height:28px;}\n' +
+        '.copyright { font-family: monospace; font-size: initial; font-weight: initial; -moz-tab-size: 4; tab-size: 4; white-space: pre-wrap; }\n' +
+        '</style>\n';
     const htmlHeader =
-	'<html>\n' +
-	'<head>\n' + 
-	htmlMeta + 
-	htmlStyle + 
-	'</head>\n' +
-	'<body>\n' +
-	'<h2>Open Source Software</h2>\n';
-	// Happy preamble of legal compliance goes here...
+        '<html>\n' +
+        '<head>\n' +
+        htmlMeta +
+        htmlStyle +
+        '</head>\n' +
+        '<body>\n' +
+        '<h2>Open Source Software</h2>\n';
+        // Happy preamble of legal compliance goes here...
     const htmlFooter =
-	'</body>\n' +
-	'</html>';
+        '</body>\n' +
+        '</html>';
 
     // send the HTML header
     msg.status_code = 200;
@@ -82,22 +82,22 @@ function getLicenseList(msg) {
 
     packageNames.sort();
     packageNames.forEach(function(packageName) {
-	const copyrightPath = GLib.build_filenamev([CRAWL_LOCATION, packageName, 'copyright']);
+        const copyrightPath = GLib.build_filenamev([CRAWL_LOCATION, packageName, 'copyright']);
 
         try {
-	    const [success, copyrightContents] = GLib.file_get_contents(copyrightPath);
+            const [success, copyrightContents] = GLib.file_get_contents(copyrightPath);
         } catch (e if e.matches(GLib.FileError, GLib.FileError.NOENT)) {
             return;
         } catch (e) {
-	    logError(e, 'Unable to read copyright file ' + copyrightPath);
+            logError(e, 'Unable to read copyright file ' + copyrightPath);
             return;
         }
 
-	const dirNames = packages[packageName];
+        const dirNames = packages[packageName];
 
-	// send HTML for this directory
+        // send HTML for this directory
         try {
-	    const html = prepareHtml(dirNames, copyrightContents.toString());
+            const html = prepareHtml(dirNames, copyrightContents.toString());
             msg.response_body.append(html);
         } catch (e) {
             logError(e, 'Unable to convert contents of ' + copyrightPath + ' to string');

--- a/licenseCrawler.js
+++ b/licenseCrawler.js
@@ -11,11 +11,7 @@ function prepareHtml(fileNames, copyright) {
     var html = '<h3 class="package-name">';
     var files = [];
 
-    files = fileNames.toString().split(',');
-    files.forEach(function(file) {
-	html += file;
-	html += '<br />';
-    });
+    html += fileNames.join('<br />');
     html += '</h3>';
 
     html += '<p class="copyright">';


### PR DESCRIPTION
It takes long enough to render the full license list on my (fast) test
hardware that I thought the FBE had crashed. I hear it's even worse on arm.

Rather than producing a single multi-megabyte page all at once, let's link
to a separate page for each package.

https://phabricator.endlessm.com/T10765