### PR TITLE
Use standard catch clauses

### DIFF
--- a/licenseCrawler.js
+++ b/licenseCrawler.js
@@ -117,13 +117,15 @@ function getLicense(msg, packageNames) {
             logError(e, html);
             statusCode = 500;
         }
-    } catch (e if e.matches(GLib.FileError, GLib.FileError.NOENT)) {
-        statusCode = 400;
-        html = 'Not found: ' + copyrightPath;
     } catch (e) {
-        html = 'Unable to read copyright file: ' + copyrightPath;
-        logError(e, html);
-        statusCode = 500;
+        if (e.matches(GLib.FileError, GLib.FileError.NOENT)) {
+            statusCode = 400;
+            html = 'Not found: ' + copyrightPath;
+        } else {
+            html = 'Unable to read copyright file: ' + copyrightPath;
+            logError(e, html);
+            statusCode = 500;
+        }
     }
 
     // send the HTML header


### PR DESCRIPTION
Per [1], conditional catch clauses are non-standard ECMAScript. Recent
gjs no longer accepts these. Embed the conditional inside a single catch
instead.

1. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch#Conditional_catch_clauses

https://phabricator.endlessm.com/T27280