### PR TITLE
Run with DynamicUser

### DIFF
--- a/eos-license-service.service.in
+++ b/eos-license-service.service.in
@@ -4,7 +4,8 @@ Wants=network.target
 
 [Service]
 ExecStart=/usr/bin/gjs -I @pkgdatadir@ @pkgdatadir@/licenseApp.js
-User=nobody
+User=eos-license-service
+DynamicUser=yes
 
 # Sandboxing
 CapabilityBoundingSet=


### PR DESCRIPTION
Back in 1bcfcc48f908c676ecd144da9755ca0d64457b60 I made this service run
as 'nobody'. This is apparently Bad And Wrong and triggers a warning in
the journal:

    Nov 17 11:55:05 camille systemd[1]: /lib/systemd/system/eos-license-service.service:7: Special user nobody configured, this is not safe!
    ░░ Subject: Special user nobody configured, this is not safe!
    ░░ Defined-By: systemd
    ░░ Support: https://www.debian.org/support
    ░░ Documentation: https://systemd.io/UIDS-GIDS
    ░░
    ░░ The unit eos-license-service.service is configured to use User=nobody.
    ░░
    ░░ This is not safe. The nobody user's main purpose on Linux-based
    ░░ operating systems is to be the owner of files that otherwise cannot be mapped
    ░░ to any local user. It's used by the NFS client and Linux user namespacing,
    ░░ among others. By running a unit's processes under the identity of this user
    ░░ they might possibly get read and even write access to such files that cannot
    ░░ otherwise be mapped.
    ░░
    ░░ It is strongly recommended to avoid running services under this user identity,
    ░░ in particular on systems using NFS or running containers. Allocate a user ID
    ░░ specific to this service, either statically via systemd-sysusers or dynamically
    ░░ via the DynamicUser= service setting.

Instead, run as an eos-license-server user, dynamically generated by
systemd so that we don't need to put an entry in /usr/lib/passwd.

https://phabricator.endlessm.com/T32731