### PR TITLE
Explicitly require libsoup 2.4

### DIFF
--- a/licenseApp.js
+++ b/licenseApp.js
@@ -1,3 +1,4 @@
+imports.gi.versions.Soup = "2.4";
 
 const GLib = imports.gi.GLib;
 const Soup = imports.gi.Soup;


### PR DESCRIPTION
We now include both libsoup-2.4 and libsoup-3 in the OSTree. If no version is specified gobject-introspection gives you a warning and the latest version, which then means the application fails to run because the API has changed incompatibly.

We should update this at some point but for the time being, making the service work is better than not.

https://phabricator.endlessm.com/T35099