### PR TITLE
WIP: Convert terms of use to HTML

### DIFF
--- a/terms/eos/C/Terms-of-Use.html
+++ b/terms/eos/C/Terms-of-Use.html
@@ -1,0 +1,635 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>Endless Terms of Use</title>
+  <style>
+    html {
+      line-height: 1.5;
+      font-family: sans-serif;
+      font-size: 11pt;;
+      color: #1a1a1a;
+      background-color: #fdfdfd;
+    }
+    body {
+      margin: 0 auto;
+      max-width: 36em;
+      padding-left: 50px;
+      padding-right: 50px;
+      padding-top: 50px;
+      padding-bottom: 50px;
+      hyphens: auto;
+      overflow-wrap: break-word;
+      text-rendering: optimizeLegibility;
+      font-kerning: normal;
+    }
+    @media (max-width: 600px) {
+      body {
+        font-size: 0.9em;
+        padding: 1em;
+      }
+      h1 {
+        font-size: 1.8em;
+      }
+    }
+    @media print {
+      body {
+        background-color: transparent;
+        color: black;
+        font-size: 12pt;
+      }
+      p, h2, h3 {
+        orphans: 3;
+        widows: 3;
+      }
+      h2, h3, h4 {
+        page-break-after: avoid;
+      }
+    }
+    p {
+      margin: 1em 0;
+    }
+    a {
+      color: #1a1a1a;
+    }
+    a:visited {
+      color: #1a1a1a;
+    }
+    img {
+      max-width: 100%;
+    }
+    h1, h2, h3, h4, h5, h6 {
+      margin-top: 1.4em;
+    }
+    h5, h6 {
+      font-size: 1em;
+      font-style: italic;
+    }
+    h6 {
+      font-weight: normal;
+    }
+    ol, ul {
+      padding-left: 1.7em;
+      margin-top: 1em;
+    }
+    li > ol, li > ul {
+      margin-top: 0;
+    }
+    blockquote {
+      margin: 1em 0 1em 1.7em;
+      padding-left: 1em;
+      border-left: 2px solid #e6e6e6;
+      color: #606060;
+    }
+    code {
+      font-family: Menlo, Monaco, 'Lucida Console', Consolas, monospace;
+      font-size: 85%;
+      margin: 0;
+    }
+    pre {
+      margin: 1em 0;
+      overflow: auto;
+    }
+    pre code {
+      padding: 0;
+      overflow: visible;
+      overflow-wrap: normal;
+    }
+    .sourceCode {
+     background-color: transparent;
+     overflow: visible;
+    }
+    hr {
+      background-color: #1a1a1a;
+      border: none;
+      height: 1px;
+      margin: 1em 0;
+    }
+    table {
+      margin: 1em 0;
+      border-collapse: collapse;
+      width: 100%;
+      overflow-x: auto;
+      display: block;
+      font-variant-numeric: lining-nums tabular-nums;
+    }
+    table caption {
+      margin-bottom: 0.75em;
+    }
+    tbody {
+      margin-top: 0.5em;
+      border-top: 1px solid #1a1a1a;
+      border-bottom: 1px solid #1a1a1a;
+    }
+    th {
+      border-top: 1px solid #1a1a1a;
+      padding: 0.25em 0.5em 0.25em 0.5em;
+    }
+    td {
+      padding: 0.125em 0.5em 0.25em 0.5em;
+    }
+    header {
+      margin-bottom: 4em;
+      text-align: center;
+    }
+    #TOC li {
+      list-style: none;
+    }
+    #TOC ul {
+      padding-left: 1.3em;
+    }
+    #TOC > ul {
+      padding-left: 0;
+    }
+    #TOC a:not(:hover) {
+      text-decoration: none;
+    }
+    code{white-space: pre-wrap;}
+    span.smallcaps{font-variant: small-caps;}
+    span.underline{text-decoration: underline;}
+    div.column{display: inline-block; vertical-align: top; width: 50%;}
+    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+    ul.task-list{list-style: none;}
+    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  </style>
+  <style>
+  body {
+    max-width: 1024px;
+  }
+  .highlight {
+    background: yellow;
+  }
+  p.highlight, div.highlight {
+    border: 2px solid black;
+  }
+  </style>
+</head>
+<body>
+<header id="title-block-header">
+<h1 class="title">Endless Terms of Use</h1>
+<p class="date"><p>Last Updated: 25 April 2022</p></p>
+</header>
+<p>Thank you for your selection of an Endless OS Foundation LLC
+(“<strong>Endless</strong>”, “<strong>we</strong>,” or
+“<strong>us</strong>”) product. Endless was created to inspire and to
+empower, and so we strive to appreciate and respect our users.</p>
+<p>These Terms of Use (the “<strong>Terms</strong>”) are a legally
+binding contract between you and Endless regarding your use of the
+Software and Services. The Terms will govern your use of the Endless
+operating system (the “<strong>OS</strong>”), the Endless and
+third-party programs included with or made available for the OS (the
+“<strong>Apps</strong>”), and other services provided by us such as
+online communications, identity, and distribution of additional
+materials, Apps and Updates (the <strong>“Services</strong>”).</p>
+<p class="highlight">
+Please read these Terms carefully. By clicking “accept” you acknowledge
+that you have read, understood, and agreed to be bound by the Terms.
+</p>
+<p>If you do not agree to these Terms, then please do not use the
+Software or the Services. If you acquired a device with the Software
+pre-loaded and do not agree to these Terms, you should return the device
+(including all accessories and materials provided with it) to the
+retailer where you purchased it and request a refund of the purchase
+price.</p>
+<p class="highlight">
+These Terms include an arbitration agreement, by which you agree that
+binding arbitration will resolve all disputes between you and Endless.
+Your rights will be determined by a neutral arbitrator, not a judge; and
+your claims cannot be brought as a class action. Please review Section
+15. below for further details.
+</p>
+<ol type="1">
+<li><p><strong>License to Endless Software and Updates.</strong></p>
+<ol type="1">
+<li><p><strong>Software</strong>. Unless specifically noted otherwise in
+writing, the OS, Apps, Updates (as defined below), and other materials
+distributed to you in connection with the Services (together, the
+“<strong>Software</strong>”) are licensed and are not sold. All Software
+is provided to you subject to a limited, individual, revocable,
+non-exclusive, non-transferrable, and non-assignable personal license to
+use the Software, subject to your compliance with these Terms. Endless
+reserves all rights to the Software not granted expressly in these
+Terms.</p></li>
+<li><p><strong>Updates</strong>. From time to time, Endless may, at its
+own discretion, create updates, upgrades, enhancements or bug fixes
+(collectively “<strong>Updates</strong>”) to the Software, and make such
+Updates available to you. The Software may automatically download and
+install Updates without user confirmation, and Updates may modify or
+remove certain functionality.</p></li>
+<li><p><strong>Copying and Distribution</strong>. You may copy and
+distribute the Software as described by any of the following
+clauses.</p>
+<ol type="1">
+<li><p><strong>Personal &amp; Non-Commercial Use</strong>: We encourage
+you to download and install the Software for personal use, or in
+non-commercial settings such as public, educational or non-profit
+institutions. You are permitted to install the Software on one or more
+devices for these purposes. Such installations must be made using
+installation methods outlined in our documentation; except as set out
+within the Terms, modifications to the Software are not
+permitted.</p></li>
+<li><p><strong>Physical Redistribution</strong>: You may redistribute
+pristine, unmodified copies of the Software on physical media such as
+CD/DVD, USB disk or SD/MMC card. If you wish, you may charge a nominal
+fee to the end user to defray your costs related to the media. No
+commercial agreement with Endless is needed.</p></li>
+<li><p><strong>Online Redistribution</strong>: You may redistribute
+pristine, unmodified copies of the Software online by becoming a public
+mirror or by utilizing our BitTorrent tracker.</p></li>
+</ol></li>
+</ol></li>
+<li><p><strong>Eligibility</strong>. You represent and warrant to us
+that you are legally able to contract with us, or that if you are under
+age, a legal guardian, tutor or parent has agreed to the terms. If you
+are using the Software or Services on behalf of an entity, organization,
+or company, you represent and warrant that you have the authority to
+bind that entity, organization, or company to these Terms and you agree
+to be bound by these Terms on behalf of that entity, organization, or
+company.</p></li>
+<li><p><strong>Content Disclaimer</strong>. When using the Software or
+Services you may be exposed to content from a variety of third party
+sources, including the internet. You acknowledge that such content may
+be inaccurate, offensive, indecent or objectionable, and you waive any
+legal or equitable rights or remedies you may have against Endless with
+respect to such content.</p></li>
+<li><p><strong>Data Collection.</strong></p>
+<ol type="1">
+<li><p><strong>Default.</strong> Certain information is reported to
+Endless periodically by the Software. This information includes the
+version of the OS which was installed and is currently being used, the
+device that is being used to run the OS and its approximate location,
+how the OS was installed, and how long the OS has been installed on that
+device.</p></li>
+<li><p><strong>Optional.</strong> Additional information may be reported
+to Endless periodically by the Software’s user metrics system. To enable
+and disable this system, use the “Privacy” settings in the OS control
+center.</p></li>
+<li><p><strong>Data Usage.</strong> Endless may process and use the data
+it collects about your usage (collectively, the Usage Information), and
+may share the Usage Information in an anonymous and aggregate form with
+third parties including, but not limited to, current and potential
+content providers, app developers and, in the specific case of the
+devices involved in their deployments, partners who are deploying the
+Software in educational or other charitable settings. In addition, when
+legally required, Usage Information may be shared with government
+agencies.</p></li>
+</ol></li>
+<li><p><strong>Prohibited Conduct</strong>. You will not:</p>
+<ol type="1">
+<li><p>use the Software or Services for any fraudulent or illegal
+purpose, or in violation of any local, state, national, or international
+law;</p></li>
+<li><p>violate the rights of third parties, including by infringing or
+misappropriating third-party intellectual property rights;</p></li>
+<li><p>attempt to do any of the foregoing in this Section 5., or assist
+or permit any persons in engaging or attempting to engage in any of the
+activities described in this Section 5..</p></li>
+</ol></li>
+<li><p><strong>Termination of Use; Discontinuation and Modification of
+the Service</strong>. If you violate any provision of these Terms, your
+permission to use the Software and Services will terminate
+automatically. You may terminate these Terms at any time by contacting
+us at <a href="mailto:legal@endlessos.org">legal@endlessos.org</a>. If
+you terminate these Terms, you will remain obligated to pay all
+outstanding fees, if any, relating to your use of the Software or
+Services incurred prior to termination. Upon termination of these Terms,
+you will cease all use of the Software and Services. Additionally,
+Endless, in its sole discretion may suspend or terminate your access to
+the Services at any time, with or without notice. We also reserve the
+right to modify or discontinue providing the Services at any time
+(including, without limitation, by limiting or discontinuing certain
+features of the Services) without notice to you.</p></li>
+<li><p><strong>Additional Terms</strong>. Your use of the Software and
+Services is subject to any and all additional terms, policies, rules, or
+guidelines applicable to the Software and Services or certain features
+we may provide now or in the future (the “<strong>Additional
+Terms</strong>”), such as end-user license agreements for any Apps that
+we may offer, or rules applicable to particular features or content on
+the Services, subject to Section 9. below. The Additional Terms may
+require you to agree to them from time to time in order to continue use
+of the Software and Services. All such Additional Terms are hereby
+incorporated by reference into, and made a part of, these
+Terms.</p></li>
+<li><p><strong>Languages and Localization</strong>. In the event of a
+dispute between the English version of these terms and any translated
+versions, the <a
+href="../../../../../../../../usr/share/eos-license-service/terms/eos/C/Terms-of-Use.pdf">English</a>
+version will govern, to the extent not prohibited by applicable law. The
+Software and Services, including Third Party Software, may not be
+available in all languages or in all countries, and Endless makes no
+representation that the Software and Services are appropriate or
+available for use in any particular location.</p></li>
+<li><p><strong>Third Party Software and Open Source</strong>.</p>
+<ol type="1">
+<li><p><strong>Third Party Terms</strong>. The Software contains
+materials, including software code, provided by third parties
+(“<strong>Third Party Software</strong>”) subject to separate license
+terms (the “<strong>Third Party Terms</strong>”). Endless has no
+obligation to provide updates, maintenance, warranty, technical or other
+support or services for Third Party Software or third-party services.
+Your use of the Third Party Software in conjunction with the Software in
+a manner consistent with the Terms is permitted. You may have broader
+rights under the applicable Third Party Terms and nothing in the Terms
+is intended to impose further restrictions on your use of the Third
+Party Software. In addition to Sections 9.3. and 9.4. below, you can
+find certain required notices and other information regarding Third
+Party Software, including open source software, <a
+href="http://localhost:3010/">here</a>.</p></li>
+<li><p><strong>Open Source Modification</strong>. Endless makes
+available some of the open source components included in the Third Party
+Software on our public GitHub account, located at <a
+href="https://github.com/endlessm"
+class="uri">https://github.com/endlessm</a>. Endless does not represent
+or warrant that the licensing information provided is correct or
+error-free, and we encourage you to notify us of any inaccurate
+information. If you make modifications to any open source software
+contained in the Software, Endless updates may overwrite such
+modifications without warning.</p></li>
+<li><p><strong>Google</strong>. Use of Google Inc.’s software and
+services in the Software is subject to the Google terms of service (<a
+href="http://www.google.com/terms_of_service.html"
+class="uri">http://www.google.com/terms_of_service.html</a>) and to
+Google’s privacy policy (<a
+href="http://www.google.com/privacypolicy.html"
+class="uri">http://www.google.com/privacypolicy.html</a>).</p></li>
+<li><p><strong>GNU</strong>. Certain Third Party Software included in
+the Software is licensed under the terms of the GNU General Public
+License (GPL) or the GNU Library/Lesser General Public License (LGPL).
+The GPL/LGPL software is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY, without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. A copy of the GPL
+and LGPL is included with the Software. If you would like a copy of the
+GPL source code used in the Software, please contact Endless as provided
+in Section 9.5. below.</p></li>
+<li><p><strong>Source Code Requests</strong>. Certain Third Party Terms,
+such as the GNU General Public License, GNU Lesser (or Library) General
+Public License, and Mozilla Public License, require Endless to make
+available the source code corresponding to free and open source binaries
+distributed under those Third Party Terms without charge except for the
+costs of media, shipping and handling. If you would like to receive a
+copy of such source code, submit a request to Endless:</p>
+<ul>
+<li><p><strong>By postal mail</strong>:</p>
+<div class="line-block">Endless OS Foundation LLC<br />
+Attn: FOSS Requests<br />
+24A Trolley Square # 2319<br />
+Wilmington, DE 19806<br />
+USA</div></li>
+<li><p><strong>By email</strong>: <a
+href="mailto:legal@endlessm.com">legal@endlessos.org</a></p></li>
+</ul>
+<p>Please include the following in your requests:</p>
+<ul>
+<li>the Software packages for which you are requesting source code;</li>
+<li>the OS and version number with which the requested Software was
+distributed;</li>
+<li>an email address and/or phone number at which we may contact you
+regarding the request (if available); and</li>
+<li>the postal address for delivery of the requested source code.</li>
+</ul>
+<p>We will make commercially reasonable efforts to honor your valid
+requests in a timely manner.</p></li>
+</ol></li>
+<li><p><strong>Indemnity.</strong> You agree that you will be solely
+responsible for your use of the Software and Services, and you agree to
+defend, indemnify, and hold harmless Endless and its officers,
+directors, employees, consultants, affiliates, subsidiaries, retailers
+and agents (collectively, the “<strong>Endless Entities</strong>”) from
+and against any and all claims, liabilities, damages, losses, and
+expenses, including reasonable attorneys’ fees and costs, arising out of
+or in any way connected with: (a) your access to, use of, or alleged use
+of the Software and Services; (b) your violation of (i) these Terms or
+any representation, warranty, or agreements referenced in the Terms,
+(ii) Third Party Terms, or (iii) any applicable law or regulation; (c)
+your modifications to open source Third Party Software (d) your
+violation of any third-party right, including without limitation any
+intellectual property right, publicity, confidentiality, property or
+privacy right; or (e) any disputes or issues between you and any third
+party. We reserve the right, at our own expense, to assume the exclusive
+defense and control of any matter otherwise subject to indemnification
+by you (and without limiting your indemnification obligations with
+respect to such matter), and in such case, you agree to cooperate with
+our defense of such claim.</p></li>
+<li><p><strong>Disclaimers; No Warranties</strong></p></li>
+</ol>
+<div class="highlight">
+<p>The Software, Services and any device hardware, and all materials and
+content available through the Software and Services, are provided “as
+is” and on an “as available” basis, without warranty or condition of any
+kind, whether express, implied, or statutory. The Endless Entities
+specifically (but without limitation) disclaim all warranties of any
+kind, whether express or implied, relating to the Software and Services
+and all materials and content available through the Software and
+Services, including but not limited to: (a) any implied warranties of
+merchantability, fitness for a particular purpose, title, satisfactory
+quality, accuracy, performance, quiet enjoyment, or non-infringement;
+and (b) any warranties arising out of course of dealing, usage, or
+trade. The Endless Entities do not warrant against interference with
+your enjoyment of the Software or Services, that the functions contained
+in or services performed or provided by Endless will meet your
+requirements or expectations, that any services will continue to be made
+available, that the Software or Services will be compatible or work with
+any third-party software, applications, or third-party services, that
+the Software or Services or any part thereof will be uninterrupted,
+secure, or free of errors, defects, viruses, or other harmful
+components, or that any of the foregoing will be corrected. Endless does
+not warrant or represent that the Software will be compatible with any
+operating systems, applications, or hardware provided by third parties.
+Installation or use of the Software may affect the usability of
+third-party software, applications, or third-party services.</p>
+<p>You assume all risk for all damages that may result from your use of
+or access to the Services, your dealings with other Services users, and
+any materials or content available through the Services. You understand
+and agree that you use the Services and use, access, download, or
+otherwise obtain materials or content through the Services and any
+associated sites or services at your own discretion and risk, and you
+will be solely responsible for any damage to your property (including
+your computer system used in connection with the service) or loss of
+data that results from the use of the Service or the download or use of
+such materials or content.</p>
+<p>You acknowledge that the Software and Services are not intended or
+suitable for use in situations or environments where the failure or time
+delays of, or errors or inaccuracies in the content, data, or
+information provided by the software or service could lead to death,
+personal injury, fire or severe physical or environmental damage,
+including without limitations the operation of nuclear facilities,
+aircraft navigation or communication systems, air traffic control, motor
+vehicles, life support, or weapons systems.</p>
+<p>No oral or written information or advice provided by Endless or its
+authorized representatives will create any warranties not expressly set
+forth in these terms. If the Software or Services prove defective and
+thereby incur any damage, you assume the entire cost of all necessary
+servicing, repair, or correction.</p>
+<p>Some jurisdictions may prohibit some disclaimers of warranties and
+you may have other rights that vary from jurisdiction to jurisdiction.
+To find about more about your rights, you should contact a local
+consumer organization, consumer protection authority, or attorney.</p>
+</div>
+<ol start="12" type="1">
+<li><strong>Limitation of Liability</strong></li>
+</ol>
+<div class="highlight">
+<p>In no event will the Endless Entities be liable to you for any
+indirect, incidental, special, consequential or punitive damages
+(including, without limitation, damages due to business interruption,
+moral damages, loss of profits, goodwill, use, data, including
+corruption of data or failure to transmit or receive any data or
+information, or other intangible losses) arising out of or relating to
+your access to or use of, your inability to access or use, or changes
+to, the Software or Services or any materials or content on the Software
+or Services, whether based on warranty, contract, tort (including
+negligence), statute or any other legal theory, whether or not the
+Endless Entities have been informed of the possibility of such
+damage.</p>
+<p>You agree that the aggregate liability of the Endless Entities to you
+for any and all claims arising out of or relating to the use of or any
+inability to use the service (including any materials or content
+available through the service, temporarily or permanently) or otherwise
+under these terms, whether in contract, tort, or otherwise, is limited
+to $50 United States Dollars or the amount you paid for the Service,
+whichever is smaller.</p>
+<p>Some jurisdictions do not allow the exclusion or limitation of
+liability for consequential or incidental damages. Accordingly, if that
+is the case, and only to that extent, the above limitation may not apply
+to you.</p>
+<p>Each provision of these terms that provides for a limitation of
+liability, disclaimer of warranties, or exclusion of damages is agreed
+to allocate the risks under these terms between the parties. This
+allocation is an essential element of the basis of the bargain between
+the parties. Each of these provisions is severable and independent of
+all other provisions of these terms. The limitations in this section 12.
+will apply even if any limited remedy fails of its essential
+purpose.</p>
+</div>
+<ol start="13" type="1">
+<li><p><strong>Export</strong>. Endless’s Software and Services may be
+subject to domestic and foreign export and reexport control laws and
+regulations. You will comply with all applicable export and reexport
+control laws and regulations, including both domestic and foreign
+controls. Specifically, you warrant that you are: (a) not located in
+Cuba, Iran, North Korea, Sudan, or Syria; and (b) not a denied party as
+specified in domestic or foreign regulations. You will not, directly or
+indirectly, sell, export, reexport, transfer, divert, or otherwise
+dispose of any products, software, or technology (including products
+derived from or based on such technology) received from Endless to any
+destination, entity, or person prohibited by applicable laws or
+regulations, including those of any other country from which the product
+has been exported, without obtaining prior authorization from the
+competent government authorities as required by those laws and
+regulations.</p></li>
+<li><p><strong>General.</strong> These Terms, together with any other
+agreements expressly incorporated by reference herein, constitute the
+entire and exclusive understanding and agreement between you and Endless
+regarding your use of and access to the Software and Services. You may
+not assign or transfer these Terms or your rights hereunder, in whole or
+in part, by operation of law or otherwise, without our prior written
+consent. We may assign these Terms at any time without notice. The
+failure to require performance of any provision will not affect our
+right to require performance at any time thereafter, nor shall a waiver
+of any breach or default of these Terms or any provision of these Terms
+constitute a waiver of any subsequent breach or default or a waiver of
+the provision itself. Use of section headers in these Terms is for
+convenience only and shall not have any impact on the interpretation of
+particular provisions. If any part of these Terms is held to be invalid
+or unenforceable, the unenforceable part shall be given effect to the
+greatest extent possible and the remaining parts will remain in full
+force and effect. Upon termination of these Terms Sections 2.-3. and
+5.-17. will survive.</p></li>
+<li><p><strong>Dispute Resolution and Arbitration</strong></p>
+<ol type="1">
+<li><p><strong>Generally.</strong> <span class="highlight">This contract
+contains an arbitration agreement. In the interest of resolving disputes
+between you and Endless in the most expedient and cost effective manner,
+you and Endless agree that any and all disputes arising in connection
+with these Terms shall be resolved by binding arbitration. Arbitration
+is more informal than a lawsuit in court. Arbitration uses a neutral
+arbitrator instead of a judge or jury, may allow for more limited
+discovery than in court, and can be subject to very limited review by
+courts. Arbitrators can award the same damages and relief that a court
+can award. Our agreement to arbitrate disputes includes, but is not
+limited to all claims arising out of or relating to any aspect of these
+Terms, whether based in contract, tort, statute, fraud,
+misrepresentation or any other legal theory, and regardless of whether
+the claims arise during or after the termination of these Terms. You
+understand and agree that, by entering into these terms, you and Endless
+are each waiving the right to a trial or to participate in a class
+action.</span></p></li>
+<li><p><strong>Exceptions</strong>. Notwithstanding subsection 15.1.,
+nothing herein will be deemed to waive, preclude, or otherwise limit
+either of our right to: (a) pursue enforcement actions through
+applicable federal, state, or local agencies where such actions are
+available; and (b) seek injunctive relief, to the extent permitted by
+law or in connection with the arbitration, in a court of law.</p></li>
+<li><p><strong>Arbitrator</strong>. Any arbitration between you and
+Endless will be governed by the Commercial Dispute Resolution Procedures
+and the Supplementary Procedures for Consumer Related Disputes
+(collectively, “<strong>AAA Rules</strong>”) of the American Arbitration
+Association (“<strong>AAA</strong>”), as modified by these Terms, and
+will be administered by the AAA. The AAA Rules and filing forms are
+available online at www.adr.org, by calling the AAA at 1-800-778-7879,
+or by contacting Endless.</p></li>
+<li><p><strong>Notice; Process</strong>. A party who intends to seek
+arbitration must first send a written notice of the dispute to the
+other, by certified mail or Federal Express (signature required), or if
+we do not have a physical address on file for you, by electronic mail
+(“<strong>Notice</strong>”). Endless’s address for Notice is: Endless OS
+Foundation LLC, 24A Trolley Square # 2319, Wilmington, DE 19806, USA.
+The Notice must (a) describe the nature and basis of the claim or
+dispute; and (b) set forth the specific relief sought
+(“<strong>Demand</strong>”). We agree to use good faith efforts to
+resolve the claim directly, but if we do not reach an agreement to do so
+within 30 calendar days after the Notice is received, you or Endless may
+commence an arbitration proceeding. During the arbitration, the amount
+of any settlement offer made by you or Endless shall not be disclosed to
+the arbitrator until after the arbitrator makes a final decision and
+award, if any. If our dispute is finally resolved through arbitration in
+your favor, Endless shall pay you (I) the amount awarded by the
+arbitrator, if any, or (II) the last written settlement amount offered
+by Endless in settlement of the dispute prior to the arbitrator’s award,
+whichever is greater.</p></li>
+<li><p><strong>No Class Actions</strong>. <span class="highlight">You
+and Endless agree that each may bring claims against the other only in
+your or its individual capacity and not as a plaintiff or class member
+in any purported class or representative proceeding. Further, unless
+both you and Endless agree otherwise, the arbitrator may not consolidate
+more than one person’s claims, and may not otherwise preside over any
+form of a representative or class proceeding.</span></p></li>
+<li><p><strong>Modifications</strong>. We may revise these Terms at any
+time without notice. By continuing to use the Software and Services
+after you have been notified of a modification, you are agreeing to be
+bound by the modified version of these Terms.</p></li>
+<li><p><strong>Enforceability</strong>. If Subsection 15.5. is found to
+be unenforceable or if the entirety of this Section 15. is found to be
+unenforceable, then the entirety of this Section 15. shall be null and
+void and, in such case, the parties agree that the exclusive
+jurisdiction and venue described in Section 18. shall govern any action
+arising out of or related to these Terms.</p></li>
+</ol></li>
+<li><p><strong>Consent to Electronic Communications</strong>. By using
+the Software and Services, you consent to receiving certain electronic
+communications from us. You agree that any notices, agreements,
+disclosures, or other communications that we send to you electronically
+will satisfy any legal communication requirements, including any
+requirements that such communications be in writing.</p></li>
+<li><p><strong>Notices and Contact.</strong> Except as set forth in
+Sections 9. and 15., all notices to Endless must be sent to Endless OS
+Foundation LLC, 24A Trolley Square # 2319, Wilmington, DE 19806, USA by
+certified mail, and will be deemed given upon receipt by Endless. All
+notices by Endless to you will be sent to the email address you have
+made available to Endless, and will be deemed given on the day sent. If
+you are a California resident, you may have these Terms mailed to you
+electronically by sending a letter to the foregoing address with your
+electronic mail address and a request for these Terms.</p></li>
+<li><p><strong>Governing Law</strong>. These Terms shall be governed by
+the laws of the State of California without regard to conflict of law
+principles. To the extent that any lawsuit or court proceeding is
+permitted hereunder and not legally subject to arbitration under the
+applicable laws, then in that case you and Endless agree to submit to
+the personal and exclusive jurisdiction of the state courts and federal
+courts located within San Francisco County, California for the purpose
+of litigating all such disputes.</p></li>
+</ol>
+</body>
+</html>

--- a/terms/eos/C/Terms-of-Use.md
+++ b/terms/eos/C/Terms-of-Use.md
@@ -1,0 +1,519 @@
+---
+title: Endless Terms of Use
+date: |
+  Last Updated: 25 April 2022
+mainfont: sans-serif
+fontsize: 11pt;
+header-includes: |
+  <style>
+  body {
+    max-width: 1024px;
+  }
+  .highlight {
+    background: yellow;
+  }
+  p.highlight, div.highlight {
+    border: 2px solid black;
+  }
+  </style>
+---
+
+Thank you for your selection of an Endless OS Foundation LLC
+("**Endless**", "**we**," or "**us**") product. Endless was created to
+inspire and to empower, and so we strive to appreciate and respect our
+users.
+
+These Terms of Use (the "**Terms**") are a legally binding contract
+between you and Endless regarding your use of the Software and Services.
+The Terms will govern your use of the Endless operating system (the
+"**OS**"), the Endless and third-party programs included with or made
+available for the OS (the "**Apps**"), and other services provided by us
+such as online communications, identity, and distribution of additional
+materials, Apps and Updates (the **"Services**").
+
+<p class=highlight>
+Please read these Terms carefully. By clicking "accept" you acknowledge
+that you have read, understood, and agreed to be bound by the Terms.
+</p>
+
+If you do not agree to these Terms, then please do not use the Software
+or the Services. If you acquired a device with the Software pre-loaded
+and do not agree to these Terms, you should return the device (including
+all accessories and materials provided with it) to the retailer where
+you purchased it and request a refund of the purchase price.
+
+<p class=highlight>
+These Terms include an arbitration agreement, by which you agree that
+binding arbitration will resolve all disputes between you and Endless.
+Your rights will be determined by a neutral arbitrator, not a judge; and
+your claims cannot be brought as a class action. Please review Section
+15. below for further details.
+</p>
+
+1.  **License to Endless Software and Updates.**
+
+    1.  **Software**. Unless specifically noted otherwise in writing,
+        the OS, Apps, Updates (as defined below), and other materials
+        distributed to you in connection with the Services (together,
+        the "**Software**") are licensed and are not sold. All Software
+        is provided to you subject to a limited, individual, revocable,
+        non-exclusive, non-transferrable, and non-assignable personal
+        license to use the Software, subject to your compliance with
+        these Terms. Endless reserves all rights to the Software not
+        granted expressly in these Terms.
+
+    2.  **Updates**. From time to time, Endless may, at its own
+        discretion, create updates, upgrades, enhancements or bug fixes
+        (collectively "**Updates**") to the Software, and make such
+        Updates available to you. The Software may automatically
+        download and install Updates without user confirmation, and
+        Updates may modify or remove certain functionality.
+
+    3.  **Copying and Distribution**. You may copy and distribute the
+        Software as described by any of the following clauses.
+
+        1.  **Personal & Non-Commercial Use**: We encourage you to
+            download and install the Software for personal use, or in
+            non-commercial settings such as public, educational or
+            non-profit institutions. You are permitted to install the
+            Software on one or more devices for these purposes. Such
+            installations must be made using installation methods
+            outlined in our documentation; except as set out within
+            the Terms, modifications to the Software are not
+            permitted.
+
+        2.  **Physical Redistribution**: You may redistribute pristine,
+            unmodified copies of the Software on physical media such
+            as CD/DVD, USB disk or SD/MMC card. If you wish, you may
+            charge a nominal fee to the end user to defray your costs
+            related to the media. No commercial agreement with Endless
+            is needed.
+
+        3.  **Online Redistribution**: You may redistribute pristine,
+            unmodified copies of the Software online by becoming a
+            public mirror or by utilizing our BitTorrent tracker.
+
+2.  **Eligibility**. You represent and warrant to us that you are
+    legally able to contract with us, or that if you are under age, a
+    legal guardian, tutor or parent has agreed to the terms. If you are
+    using the Software or Services on behalf of an entity, organization,
+    or company, you represent and warrant that you have the authority to
+    bind that entity, organization, or company to these Terms and you
+    agree to be bound by these Terms on behalf of that entity,
+    organization, or company.
+
+3.  **Content Disclaimer**. When using the Software or Services you may
+    be exposed to content from a variety of third party sources,
+    including the internet. You acknowledge that such content may be
+    inaccurate, offensive, indecent or objectionable, and you waive any
+    legal or equitable rights or remedies you may have against Endless
+    with respect to such content.
+
+4.  **Data Collection.**
+
+    1.  **Default.** Certain information is reported to Endless
+        periodically by the Software. This information includes the
+        version of the OS which was installed and is currently being
+        used, the device that is being used to run the OS and its
+        approximate location, how the OS was installed, and how long the
+        OS has been installed on that device.
+
+    2.  **Optional.** Additional information may be reported to Endless
+        periodically by the Software's user metrics system. To enable
+        and disable this system, use the "Privacy" settings in the OS
+        control center.
+
+    3.  **Data Usage.** Endless may process and use the data it collects
+        about your usage (collectively, the Usage Information), and may
+        share the Usage Information in an anonymous and aggregate form
+        with third parties including, but not limited to, current and
+        potential content providers, app developers and, in the specific
+        case of the devices involved in their deployments, partners who
+        are deploying the Software in educational or other charitable
+        settings. In addition, when legally required, Usage Information
+        may be shared with government agencies.
+
+5.  **Prohibited Conduct**. You will not:
+
+    1.  use the Software or Services for any fraudulent or illegal
+        purpose, or in violation of any local, state, national, or
+        international law;
+
+    2.  violate the rights of third parties, including by infringing or
+        misappropriating third-party intellectual property rights;
+
+    3.  attempt to do any of the foregoing in this Section 5., or assist
+        or permit any persons in engaging or attempting to engage in any
+        of the activities described in this Section 5..
+
+6.  **Termination of Use; Discontinuation and Modification of the
+    Service**. If you violate any provision of these Terms, your
+    permission to use the Software and Services will terminate
+    automatically. You may terminate these Terms at any time by
+    contacting us at
+    [legal@endlessos.org](mailto:legal@endlessos.org). If
+    you terminate these Terms, you will remain obligated to pay all
+    outstanding fees, if any, relating to your use of the Software or
+    Services incurred prior to termination. Upon termination of these
+    Terms, you will cease all use of the Software and Services.
+    Additionally, Endless, in its sole discretion may suspend or
+    terminate your access to the Services at any time, with or without
+    notice. We also reserve the right to modify or discontinue providing
+    the Services at any time (including, without limitation, by limiting
+    or discontinuing certain features of the Services) without notice to
+    you.
+
+7.  **Additional Terms**. Your use of the Software and Services is
+    subject to any and all additional terms, policies, rules, or
+    guidelines applicable to the Software and Services or certain
+    features we may provide now or in the future (the "**Additional
+    Terms**"), such as end-user license agreements for any Apps that we
+    may offer, or rules applicable to particular features or content on
+    the Services, subject to Section 9. below. The Additional Terms may
+    require you to agree to them from time to time in order to continue
+    use of the Software and Services. All such Additional Terms are
+    hereby incorporated by reference into, and made a part of, these
+    Terms.
+
+8.  **Languages and Localization**. In the event of a dispute between
+    the English version of these terms and any translated versions, the
+    [English](../../../../../../../../usr/share/eos-license-service/terms/eos/C/Terms-of-Use.pdf)
+    version will govern, to the extent not prohibited by applicable law.
+    The Software and Services, including Third Party Software, may not
+    be available in all languages or in all countries, and Endless makes
+    no representation that the Software and Services are appropriate or
+    available for use in any particular location.
+
+9.  **Third Party Software and Open Source**.
+
+    1.  **Third Party Terms**. The Software contains materials,
+        including software code, provided by third parties ("**Third
+        Party Software**") subject to separate license terms (the
+        "**Third Party Terms**"). Endless has no obligation to provide
+        updates, maintenance, warranty, technical or other support or
+        services for Third Party Software or third-party services. Your
+        use of the Third Party Software in conjunction with the Software
+        in a manner consistent with the Terms is permitted. You may have
+        broader rights under the applicable Third Party Terms and
+        nothing in the Terms is intended to impose further restrictions
+        on your use of the Third Party Software. In addition to Sections
+        9.3. and 9.4. below, you can find certain required notices and
+        other information regarding Third Party Software, including open
+        source software, [here](http://localhost:3010/).
+
+    2.  **Open Source Modification**. Endless makes available some of
+        the open source components included in the Third Party Software
+        on our public GitHub account, located at
+        <https://github.com/endlessm>. Endless does not represent or
+        warrant that the licensing information provided is correct or
+        error-free, and we encourage you to notify us of any inaccurate
+        information. If you make modifications to any open source
+        software contained in the Software, Endless updates may
+        overwrite such modifications without warning.
+
+    3.  **Google**. Use of Google Inc.'s software and services in the
+        Software is subject to the Google terms of service
+        (<http://www.google.com/terms_of_service.html>) and to Google's
+        privacy policy (<http://www.google.com/privacypolicy.html>).
+
+    4.  **GNU**. Certain Third Party Software included in the Software
+        is licensed under the terms of the GNU General Public License
+        (GPL) or the GNU Library/Lesser General Public License (LGPL).
+        The GPL/LGPL software is distributed in the hope that it will be
+        useful, but WITHOUT ANY WARRANTY, without even the implied
+        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+        A copy of the GPL and LGPL is included with the Software. If you
+        would like a copy of the GPL source code used in the Software,
+        please contact Endless as provided in Section 9.5. below.
+
+    5.  **Source Code Requests**. Certain Third Party Terms, such as the
+        GNU General Public License, GNU Lesser (or Library) General
+        Public License, and Mozilla Public License, require Endless to
+        make available the source code corresponding to free and open
+        source binaries distributed under those Third Party Terms
+        without charge except for the costs of media, shipping and
+        handling. If you would like to receive a copy of such source
+        code, submit a request to Endless:
+
+        - **By postal mail**:
+
+          | Endless OS Foundation LLC
+          | Attn: FOSS Requests
+          | 24A Trolley Square \# 2319
+          | Wilmington, DE 19806
+          | USA
+
+        - **By email**: 
+          [legal@endlessos.org](mailto:legal@endlessm.com)
+
+        Please include the following in your requests:
+
+        -   the Software packages for which you are requesting source code;
+        -   the OS and version number with which the requested Software was
+            distributed;
+        -   an email address and/or phone number at which we may contact you
+            regarding the request (if available); and
+        -   the postal address for delivery of the requested source code.
+
+        We will make commercially reasonable efforts to honor your valid
+        requests in a timely manner.
+
+10. **Indemnity.** You agree that you will be solely responsible for
+    your use of the Software and Services, and you agree to defend,
+    indemnify, and hold harmless Endless and its officers, directors,
+    employees, consultants, affiliates, subsidiaries, retailers and
+    agents (collectively, the "**Endless Entities**") from and against
+    any and all claims, liabilities, damages, losses, and expenses,
+    including reasonable attorneys' fees and costs, arising out of or
+    in any way connected with: (a) your access to, use of, or alleged
+    use of the Software and Services; (b) your violation of (i) these
+    Terms or any representation, warranty, or agreements referenced in
+    the Terms, (ii) Third Party Terms, or (iii) any applicable law or
+    regulation; (c) your modifications to open source Third Party
+    Software (d) your violation of any third-party right, including
+    without limitation any intellectual property right, publicity,
+    confidentiality, property or privacy right; or (e) any disputes or
+    issues between you and any third party. We reserve the right, at our
+    own expense, to assume the exclusive defense and control of any
+    matter otherwise subject to indemnification by you (and without
+    limiting your indemnification obligations with respect to such
+    matter), and in such case, you agree to cooperate with our defense
+    of such claim.
+
+11. **Disclaimers; No Warranties**
+
+<div class=highlight>
+The Software, Services and any device hardware, and all materials and
+content available through the Software and Services, are provided "as
+is" and on an "as available" basis, without warranty or condition of
+any kind, whether express, implied, or statutory. The Endless Entities
+specifically (but without limitation) disclaim all warranties of any
+kind, whether express or implied, relating to the Software and Services
+and all materials and content available through the Software and
+Services, including but not limited to: (a) any implied warranties of
+merchantability, fitness for a particular purpose, title, satisfactory
+quality, accuracy, performance, quiet enjoyment, or non-infringement;
+and (b) any warranties arising out of course of dealing, usage, or
+trade. The Endless Entities do not warrant against interference with
+your enjoyment of the Software or Services, that the functions contained
+in or services performed or provided by Endless will meet your
+requirements or expectations, that any services will continue to be made
+available, that the Software or Services will be compatible or work with
+any third-party software, applications, or third-party services, that
+the Software or Services or any part thereof will be uninterrupted,
+secure, or free of errors, defects, viruses, or other harmful
+components, or that any of the foregoing will be corrected. Endless does
+not warrant or represent that the Software will be compatible with any
+operating systems, applications, or hardware provided by third parties.
+Installation or use of the Software may affect the usability of
+third-party software, applications, or third-party services.
+
+You assume all risk for all damages that may result from your use of or
+access to the Services, your dealings with other Services users, and any
+materials or content available through the Services. You understand and
+agree that you use the Services and use, access, download, or otherwise
+obtain materials or content through the Services and any associated
+sites or services at your own discretion and risk, and you will be
+solely responsible for any damage to your property (including your
+computer system used in connection with the service) or loss of data
+that results from the use of the Service or the download or use of such
+materials or content.
+
+You acknowledge that the Software and Services are not intended or
+suitable for use in situations or environments where the failure or time
+delays of, or errors or inaccuracies in the content, data, or
+information provided by the software or service could lead to death,
+personal injury, fire or severe physical or environmental damage,
+including without limitations the operation of nuclear facilities,
+aircraft navigation or communication systems, air traffic control, motor
+vehicles, life support, or weapons systems.
+
+No oral or written information or advice provided by Endless or its
+authorized representatives will create any warranties not expressly set
+forth in these terms. If the Software or Services prove defective and
+thereby incur any damage, you assume the entire cost of all necessary
+servicing, repair, or correction.
+
+Some jurisdictions may prohibit some disclaimers of warranties and you
+may have other rights that vary from jurisdiction to jurisdiction. To
+find about more about your rights, you should contact a local consumer
+organization, consumer protection authority, or attorney.
+</div>
+
+12. **Limitation of Liability**
+
+<div class=highlight>
+In no event will the Endless Entities be liable to you for any indirect,
+incidental, special, consequential or punitive damages (including,
+without limitation, damages due to business interruption, moral damages,
+loss of profits, goodwill, use, data, including corruption of data or
+failure to transmit or receive any data or information, or other
+intangible losses) arising out of or relating to your access to or use
+of, your inability to access or use, or changes to, the Software or
+Services or any materials or content on the Software or Services,
+whether based on warranty, contract, tort (including negligence),
+statute or any other legal theory, whether or not the Endless Entities
+have been informed of the possibility of such damage.
+
+You agree that the aggregate liability of the Endless Entities to you
+for any and all claims arising out of or relating to the use of or any
+inability to use the service (including any materials or content
+available through the service, temporarily or permanently) or otherwise
+under these terms, whether in contract, tort, or otherwise, is limited
+to \$50 United States Dollars or the amount you paid for the Service,
+whichever is smaller.
+
+Some jurisdictions do not allow the exclusion or limitation of liability
+for consequential or incidental damages. Accordingly, if that is the
+case, and only to that extent, the above limitation may not apply to
+you.
+
+Each provision of these terms that provides for a limitation of
+liability, disclaimer of warranties, or exclusion of damages is agreed
+to allocate the risks under these terms between the parties. This
+allocation is an essential element of the basis of the bargain between
+the parties. Each of these provisions is severable and independent of
+all other provisions of these terms. The limitations in this section 12.
+will apply even if any limited remedy fails of its essential purpose.
+</div>
+
+13. **Export**. Endless's Software and Services may be subject to
+    domestic and foreign export and reexport control laws and
+    regulations. You will comply with all applicable export and reexport
+    control laws and regulations, including both domestic and foreign
+    controls. Specifically, you warrant that you are: (a) not located in
+    Cuba, Iran, North Korea, Sudan, or Syria; and (b) not a denied party
+    as specified in domestic or foreign regulations. You will not,
+    directly or indirectly, sell, export, reexport, transfer, divert, or
+    otherwise dispose of any products, software, or technology
+    (including products derived from or based on such technology)
+    received from Endless to any destination, entity, or person
+    prohibited by applicable laws or regulations, including those of any
+    other country from which the product has been exported, without
+    obtaining prior authorization from the competent government
+    authorities as required by those laws and regulations.
+
+14. **General.** These Terms, together with any other agreements
+    expressly incorporated by reference herein, constitute the entire
+    and exclusive understanding and agreement between you and Endless
+    regarding your use of and access to the Software and Services. You
+    may not assign or transfer these Terms or your rights hereunder, in
+    whole or in part, by operation of law or otherwise, without our
+    prior written consent. We may assign these Terms at any time without
+    notice. The failure to require performance of any provision will not
+    affect our right to require performance at any time thereafter, nor
+    shall a waiver of any breach or default of these Terms or any
+    provision of these Terms constitute a waiver of any subsequent
+    breach or default or a waiver of the provision itself. Use of
+    section headers in these Terms is for convenience only and shall not
+    have any impact on the interpretation of particular provisions. If
+    any part of these Terms is held to be invalid or unenforceable, the
+    unenforceable part shall be given effect to the greatest extent
+    possible and the remaining parts will remain in full force and
+    effect. Upon termination of these Terms Sections 2.-3. and 5.-17.
+    will survive.
+
+15. **Dispute Resolution and Arbitration**
+
+    1.  **Generally.** <span class=highlight>This contract contains an arbitration agreement. In
+        the interest of resolving disputes between you and Endless in
+        the most expedient and cost effective manner, you and Endless
+        agree that any and all disputes arising in connection with these
+        Terms shall be resolved by binding arbitration. Arbitration is
+        more informal than a lawsuit in court. Arbitration uses a
+        neutral arbitrator instead of a judge or jury, may allow for
+        more limited discovery than in court, and can be subject to very
+        limited review by courts. Arbitrators can award the same damages
+        and relief that a court can award. Our agreement to arbitrate
+        disputes includes, but is not limited to all claims arising out
+        of or relating to any aspect of these Terms, whether based in
+        contract, tort, statute, fraud, misrepresentation or any other
+        legal theory, and regardless of whether the claims arise during
+        or after the termination of these Terms. You understand and
+        agree that, by entering into these terms, you and Endless are
+        each waiving the right to a trial or to participate in a class
+        action.</span>
+
+    2.  **Exceptions**. Notwithstanding subsection 15.1., nothing herein
+        will be deemed to waive, preclude, or otherwise limit either of
+        our right to: (a) pursue enforcement actions through applicable
+        federal, state, or local agencies where such actions are
+        available; and (b) seek injunctive relief, to the extent
+        permitted by law or in connection with the arbitration, in a
+        court of law.
+
+    3.  **Arbitrator**. Any arbitration between you and Endless will be
+        governed by the Commercial Dispute Resolution Procedures and the
+        Supplementary Procedures for Consumer Related Disputes
+        (collectively, "**AAA Rules**") of the American Arbitration
+        Association ("**AAA**"), as modified by these Terms, and will
+        be administered by the AAA. The AAA Rules and filing forms are
+        available online at www.adr.org, by calling the AAA at
+        1-800-778-7879, or by contacting Endless.
+
+    4.  **Notice; Process**. A party who intends to seek arbitration
+        must first send a written notice of the dispute to the other, by
+        certified mail or Federal Express (signature required), or if we
+        do not have a physical address on file for you, by electronic
+        mail ("**Notice**"). Endless's address for Notice is: Endless
+        OS Foundation LLC, 24A Trolley Square \# 2319, Wilmington, DE
+        19806, USA. The Notice must (a) describe the nature and basis of
+        the claim or dispute; and (b) set forth the specific relief
+        sought ("**Demand**"). We agree to use good faith efforts to
+        resolve the claim directly, but if we do not reach an agreement
+        to do so within 30 calendar days after the Notice is received,
+        you or Endless may commence an arbitration proceeding. During
+        the arbitration, the amount of any settlement offer made by you
+        or Endless shall not be disclosed to the arbitrator until after
+        the arbitrator makes a final decision and award, if any. If our
+        dispute is finally resolved through arbitration in your favor,
+        Endless shall pay you (I) the amount awarded by the arbitrator,
+        if any, or (II) the last written settlement amount offered by
+        Endless in settlement of the dispute prior to the arbitrator's
+        award, whichever is greater.
+
+    5.  **No Class Actions**. <span class=highlight>You and Endless agree that each may bring
+        claims against the other only in your or its individual capacity
+        and not as a plaintiff or class member in any purported class or
+        representative proceeding. Further, unless both you and Endless
+        agree otherwise, the arbitrator may not consolidate more than
+        one person's claims, and may not otherwise preside over any form
+        of a representative or class proceeding.</span>
+
+    6.  **Modifications**. We may revise these Terms at any time without
+        notice. By continuing to use the Software and Services after you
+        have been notified of a modification, you are agreeing to be
+        bound by the modified version of these Terms.
+
+    7.  **Enforceability**. If Subsection 15.5. is found to be
+        unenforceable or if the entirety of this Section 15. is found to
+        be unenforceable, then the entirety of this Section 15. shall be
+        null and void and, in such case, the parties agree that the
+        exclusive jurisdiction and venue described in Section 18. shall
+        govern any action arising out of or related to these Terms.
+
+16. **Consent to Electronic Communications**. By using the Software and
+    Services, you consent to receiving certain electronic communications
+    from us. You agree that any notices, agreements, disclosures, or
+    other communications that we send to you electronically will satisfy
+    any legal communication requirements, including any requirements
+    that such communications be in writing.
+
+17. **Notices and Contact.** Except as set forth in Sections 9. and 15.,
+    all notices to Endless must be sent to Endless OS Foundation LLC,
+    24A Trolley Square \# 2319, Wilmington, DE 19806, USA by certified
+    mail, and will be deemed given upon receipt by Endless. All notices
+    by Endless to you will be sent to the email address you have made
+    available to Endless, and will be deemed given on the day sent. If
+    you are a California resident, you may have these Terms mailed to
+    you electronically by sending a letter to the foregoing address with
+    your electronic mail address and a request for these Terms.
+
+18. **Governing Law**. These Terms shall be governed by the laws of the
+    State of California without regard to conflict of law principles. To
+    the extent that any lawsuit or court proceeding is permitted
+    hereunder and not legally subject to arbitration under the
+    applicable laws, then in that case you and Endless agree to submit
+    to the personal and exclusive jurisdiction of the state courts and
+    federal courts located within San Francisco County, California for
+    the purpose of litigating all such disputes.


### PR DESCRIPTION
First I converted the docx file to Markdown:

    pandoc terms/eos/C/Terms-of-Use.docx -t markdown  > terms/eos/C/Terms-of-Use.md

Then I manually adjusted a bunch of stuff:

- Fixed some dodgy formatting, particularly the Source Code Requests section

- Tweaked some links

- Changed \" to " throughout to allow Pandoc to make the quotes curly

- Added some custom CSS to highlight paragraphs, divs and spans with the .highlight class; and wrapped appropriate sections with such a class

- Used the YAML header block to override some features of Pandoc's default style sheet.

Then I converted it to a standalone HTML file:

    pandoc -s terms/eos/C/Terms-of-Use.md  > terms/eos/C/Terms-of-Use.html

Shortcomings:

- Nested bullets in the original document are numbered like 1.3.1., 9.3; but in the resulting HTML only the current level of numbering is used. This is as far as I know an HTML limitation. I do not know if the 1.3.1.-style numbering has legal significance.

- Links are black with underlines, not blue with underlines.

- The logo is missing.

- The header has too much spacing for my taste.

Improvements:

- It matches the system font, including adapting to the Large Text a11y setting when enabled (thanks to WebKitGTK).

- It loads quickly!

- It doesn't get loads of PDF.js junk around it!

https://phabricator.endlessm.com/T35231